### PR TITLE
Rendering book producers as nodes, and displaying city current name

### DIFF
--- a/haskala/modules/custom/haskala_book/haskala_book.features.field_base.inc
+++ b/haskala/modules/custom/haskala_book/haskala_book.features.field_base.inc
@@ -2859,7 +2859,7 @@ function haskala_book_field_default_field_bases() {
     'module' => 'list',
     'settings' => array(
       'allowed_values' => array(
-        0 => '',
+        0 => 'No',
         1 => 'Yes',
       ),
       'allowed_values_function' => '',

--- a/haskala/modules/custom/haskala_book/haskala_book.features.field_instance.inc
+++ b/haskala/modules/custom/haskala_book/haskala_book.features.field_instance.inc
@@ -7239,11 +7239,7 @@ function haskala_book_field_default_field_instances() {
   // Exported field_instance: 'node-production-field_person_name_appear'
   $field_instances['node-production-field_person_name_appear'] = array(
     'bundle' => 'production',
-    'default_value' => array(
-      0 => array(
-        'value' => 0,
-      ),
-    ),
+    'default_value' => NULL,
     'deleted' => 0,
     'description' => '',
     'display' => array(
@@ -7263,7 +7259,7 @@ function haskala_book_field_default_field_instances() {
     ),
     'entity_type' => 'node',
     'field_name' => 'field_person_name_appear',
-    'label' => 'Does the person\'s name appear in the book?',
+    'label' => 'Person\'s name appear in the book',
     'required' => 0,
     'settings' => array(
       'user_register_form' => FALSE,
@@ -7271,10 +7267,8 @@ function haskala_book_field_default_field_instances() {
     'widget' => array(
       'active' => 1,
       'module' => 'options',
-      'settings' => array(
-        'display_label' => 1,
-      ),
-      'type' => 'options_onoff',
+      'settings' => array(),
+      'type' => 'options_buttons',
       'weight' => 6,
     ),
   );
@@ -7588,7 +7582,6 @@ function haskala_book_field_default_field_instances() {
   t('Contemporary disputes about the book');
   t('Contemporary references to the book');
   t('Copy of book used');
-  t('Does the person\'s name appear in the book?');
   t('Edition of book');
   t('Evidence about book production');
   t('Evidence for person\'s identity if it does not appear in the book');
@@ -7662,6 +7655,7 @@ function haskala_book_field_default_field_instances() {
   t('Pages in which illustrations / diagrams appear');
   t('Part of a series of books? ');
   t('Partial publication of the book in other texts');
+  t('Person\'s name appear in the book');
   t('Place of publication as it appears in other sources');
   t('Place of publication as it appears in the book');
   t('Place of publication of original text');

--- a/haskala/modules/custom/haskala_book/haskala_book.features.field_instance.inc
+++ b/haskala/modules/custom/haskala_book/haskala_book.features.field_instance.inc
@@ -7524,10 +7524,10 @@ function haskala_book_field_default_field_instances() {
     'description' => '',
     'display' => array(
       'default' => array(
-        'label' => 'above',
-        'module' => 'taxonomy',
+        'label' => 'hidden',
+        'module' => 'haskala_terms',
         'settings' => array(),
-        'type' => 'taxonomy_term_reference_link',
+        'type' => 'haskala_terms_detailed',
         'weight' => 10,
       ),
       'teaser' => array(

--- a/haskala/modules/custom/haskala_book/haskala_book.features.field_instance.inc
+++ b/haskala/modules/custom/haskala_book/haskala_book.features.field_instance.inc
@@ -7125,11 +7125,8 @@ function haskala_book_field_default_field_instances() {
     'display' => array(
       'default' => array(
         'label' => 'above',
-        'module' => 'entityreference',
-        'settings' => array(
-          'link' => FALSE,
-        ),
-        'type' => 'entityreference_label',
+        'settings' => array(),
+        'type' => 'hidden',
         'weight' => 0,
       ),
       'teaser' => array(
@@ -7293,7 +7290,7 @@ function haskala_book_field_default_field_instances() {
         'label' => 'above',
         'module' => 'entityreference',
         'settings' => array(
-          'link' => FALSE,
+          'link' => 1,
         ),
         'type' => 'entityreference_label',
         'weight' => 2,

--- a/haskala/modules/custom/haskala_book/haskala_book.field_group.inc
+++ b/haskala/modules/custom/haskala_book/haskala_book.field_group.inc
@@ -805,41 +805,6 @@ function haskala_book_field_group_info() {
   $field_group = new stdClass();
   $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
   $field_group->api_version = 1;
-  $field_group->identifier = 'group_producers|node|production|default';
-  $field_group->group_name = 'group_producers';
-  $field_group->entity_type = 'node';
-  $field_group->bundle = 'production';
-  $field_group->mode = 'default';
-  $field_group->parent_name = '';
-  $field_group->data = array(
-    'label' => 'Book producers',
-    'weight' => '1',
-    'children' => array(
-      0 => 'field_name_in_book',
-      1 => 'field_person_book_references',
-      2 => 'field_person_name_appear',
-      3 => 'field_producer',
-      4 => 'field_producer_evidence',
-      5 => 'field_religion',
-      6 => 'field_role',
-      7 => 'field_roles_notes',
-      8 => 'field_writing_age',
-      9 => 'field_writing_location',
-    ),
-    'format_type' => 'fieldset',
-    'format_settings' => array(
-      'formatter' => 'collapsible',
-      'instance_settings' => array(
-        'description' => '',
-        'classes' => '',
-      ),
-    ),
-  );
-  $export['group_producers|node|production|default'] = $field_group;
-
-  $field_group = new stdClass();
-  $field_group->disabled = FALSE; /* Edit this to true to make a default field_group disabled initially */
-  $field_group->api_version = 1;
   $field_group->identifier = 'group_publisher_printing_press|node|book|default';
   $field_group->group_name = 'group_publisher_printing_press';
   $field_group->entity_type = 'node';

--- a/haskala/modules/custom/haskala_book/haskala_book.info
+++ b/haskala/modules/custom/haskala_book/haskala_book.info
@@ -223,7 +223,6 @@ features[field_group][] = group_prefaces|node|book|default
 features[field_group][] = group_prefaces|node|book|form
 features[field_group][] = group_preservation|node|book|default
 features[field_group][] = group_preservation|node|book|form
-features[field_group][] = group_producers|node|production|default
 features[field_group][] = group_publisher_printing_press|node|book|default
 features[field_group][] = group_publisher_printing_press|node|book|form
 features[field_group][] = group_references_bibliography|node|book|default

--- a/haskala/modules/custom/haskala_book/haskala_book.module
+++ b/haskala/modules/custom/haskala_book/haskala_book.module
@@ -36,7 +36,6 @@ function haskala_book_get_production($book_nid, $person_nid = NULL, $role = NULL
     ->propertyCondition('status', NODE_PUBLISHED)
     ->fieldCondition('field_book', 'target_id', $book_nid);
   if ($person_nid) {
-
     $query->fieldCondition('field_producer', 'target_id', $person_nid);
   }
   if ($role) {
@@ -325,29 +324,6 @@ function haskala_book_get_mentions($book_nid) {
  * @return array
  */
 function haskala_book_hebrew_alphabet_without_sofit() {
-  return array(
-    'א',
-    'ב',
-    'ג',
-    'ד',
-    'ה',
-    'ו',
-    'ז',
-    'ח',
-    'ט',
-    'י',
-    'כ',
-    'ל',
-    'מ',
-    'נ',
-    'ס',
-    'ע',
-    'פ',
-    'צ',
-    'ק',
-    'ר',
-    'ש',
-    'ת',
-  );
+  return array('א', 'ב', 'ג', 'ד', 'ה', 'ו', 'ז', 'ח', 'ט', 'י', 'כ', 'ל', 'מ', 'נ', 'ס', 'ע', 'פ', 'צ', 'ק', 'ר', 'ש', 'ת');
 }
 

--- a/haskala/modules/custom/haskala_book/plugins/content_types/book_fields/book_fields.inc
+++ b/haskala/modules/custom/haskala_book/plugins/content_types/book_fields/book_fields.inc
@@ -107,15 +107,15 @@ function haskala_book_book_fields_content_type_render($subtype, $conf, $args, $c
  */
 function haskala_book_production_tab_fields(&$tabs_fields, $book_nid) {
   $productions_nodes = haskala_book_get_production($book_nid);
-  if ($productions_nodes) {
-    $tabs_fields[t('Book producers')] = array();
-    foreach($productions_nodes as $production_node) {
-      $production_wrapper = entity_metadata_wrapper('node', $production_node);
-      $production_tab = field_group_load_field_group('group_producers', 'node', 'production', 'default');
-      $production_node_view = node_view($production_node);
-      $tabs_fields[t('Book producers')][] = haskala_book_get_tab_fields($production_wrapper, $production_tab, $production_node_view, $book_nid);
-    }
+  if (!$productions_nodes) {
+    return;
   }
+
+  $producers = array();
+  foreach($productions_nodes as $production_node) {
+    $producers[] = array(render(node_view($production_node)));
+  }
+  $tabs_fields[t('Book producers')] = $producers;
 }
 
 /**

--- a/haskala/modules/custom/haskala_book/plugins/content_types/book_fields/book_fields.inc
+++ b/haskala/modules/custom/haskala_book/plugins/content_types/book_fields/book_fields.inc
@@ -113,7 +113,8 @@ function haskala_book_production_tab_fields(&$tabs_fields, $book_nid) {
 
   $producers = array();
   foreach($productions_nodes as $production_node) {
-    $producers[] = array(render(node_view($production_node)));
+    $node_view = node_view($production_node);
+    $producers[] = array(render($node_view));
   }
   $tabs_fields[t('Book producers')] = $producers;
 }

--- a/haskala/modules/custom/haskala_book/plugins/content_types/book_fields/haskala-book-fields.tpl.php
+++ b/haskala/modules/custom/haskala_book/plugins/content_types/book_fields/haskala-book-fields.tpl.php
@@ -60,7 +60,7 @@
               </div>
             <?php else: ?>
               <div class="fields-multi">
-                <?php foreach($single_tab_fields as $key_field => $tab_field): ?>
+                <?php foreach ($single_tab_fields as $key_field => $tab_field): ?>
                   <?php // Sub group in tab if exist.
                   if ($key_field === 'sub_title'): ?>
                     <div class="tab-sub-title">

--- a/haskala/modules/custom/haskala_mention/haskala_mention.views_default.inc
+++ b/haskala/modules/custom/haskala_mention/haskala_mention.views_default.inc
@@ -76,7 +76,7 @@ function haskala_mention_views_default_views() {
       'empty_column' => 0,
     ),
   );
-  /* Field: Content: Mentioned in book */
+  /* Field: Content: Producer of book */
   $handler->display->display_options['fields']['field_book']['id'] = 'field_book';
   $handler->display->display_options['fields']['field_book']['table'] = 'field_data_field_book';
   $handler->display->display_options['fields']['field_book']['field'] = 'field_book';

--- a/haskala/modules/custom/haskala_mention/haskala_mention.views_default.inc
+++ b/haskala/modules/custom/haskala_mention/haskala_mention.views_default.inc
@@ -76,7 +76,7 @@ function haskala_mention_views_default_views() {
       'empty_column' => 0,
     ),
   );
-  /* Field: Content: Producer of book */
+  /* Field: Content: Mentioned in book */
   $handler->display->display_options['fields']['field_book']['id'] = 'field_book';
   $handler->display->display_options['fields']['field_book']['table'] = 'field_data_field_book';
   $handler->display->display_options['fields']['field_book']['field'] = 'field_book';

--- a/haskala/modules/custom/haskala_terms/haskala_terms.features.field_instance.inc
+++ b/haskala/modules/custom/haskala_terms/haskala_terms.features.field_instance.inc
@@ -24,10 +24,31 @@ function haskala_terms_field_default_field_instances() {
         'type' => 'text_default',
         'weight' => 0,
       ),
+      'detailed' => array(
+        'label' => 'above',
+        'module' => 'text',
+        'settings' => array(),
+        'type' => 'text_plain',
+        'weight' => 0,
+      ),
+      'teaser' => array(
+        'label' => 'above',
+        'module' => 'text',
+        'settings' => array(),
+        'type' => 'text_plain',
+        'weight' => 0,
+      ),
+      'term_teaser' => array(
+        'label' => 'above',
+        'module' => 'text',
+        'settings' => array(),
+        'type' => 'text_plain',
+        'weight' => 0,
+      ),
     ),
     'entity_type' => 'taxonomy_term',
     'field_name' => 'field_current_name',
-    'label' => 'Current name',
+    'label' => 'Current name of location',
     'required' => 0,
     'settings' => array(
       'text_processing' => 0,
@@ -46,7 +67,7 @@ function haskala_terms_field_default_field_instances() {
 
   // Translatables
   // Included for use with string extractors like potx.
-  t('Current name');
+  t('Current name of location');
 
   return $field_instances;
 }

--- a/haskala/modules/custom/haskala_terms/haskala_terms.module
+++ b/haskala/modules/custom/haskala_terms/haskala_terms.module
@@ -14,3 +14,41 @@ function haskala_terms_ctools_plugin_directory($module, $plugin) {
     return 'plugins/' . $plugin;
   }
 }
+
+/**
+ * Implements hook_entity_info_alter().
+ */
+function haskala_terms_entity_info_alter(&$entity_info) {
+  $entity_info['taxonomy_term']['view modes']['detailed'] = array(
+    'label' => t('Detailed'),
+    'custom settings' => TRUE,
+  );
+}
+
+/**
+ * Implements hook_field_formatter_info().
+ */
+function haskala_terms_field_formatter_info() {
+  return array(
+    'haskala_terms_detailed' => array(
+      'label' => t('Detailed'),
+      'field types' => array('taxonomy_term_reference'),
+    ),
+  );
+}
+
+/**
+ * Implements hook_field_formatter_view().
+ */
+function haskala_terms_field_formatter_view($entity_type, $entity, $field, $instance, $langcode, $items, $display) {
+  if ($display['type'] != 'haskala_terms_detailed') {
+    return;
+  }
+
+  $element = array();
+  foreach ($items as $delta => $item) {
+    $element[$delta] = taxonomy_term_view(taxonomy_term_load($item['tid']), 'detailed');
+  }
+
+  return $element;
+}

--- a/haskala/themes/custom/haskala_theme/template.php
+++ b/haskala/themes/custom/haskala_theme/template.php
@@ -89,5 +89,12 @@ function haskala_theme_preprocess_taxonomy_term(&$variables) {
 function haskala_theme_preprocess_taxonomy_term__teaser(&$variables) {
   $term = $variables['term'];
   $variables['url'] = url('taxonomy/term/' . $term->tid);
-  $variables['title'] =$term->name;
+  $variables['title'] = $term->name;
+}
+
+/**
+ * Preprocess for taxonomy term teaser.
+ */
+function haskala_theme_preprocess_taxonomy_term__detailed(&$variables) {
+  $variables['title_label'] = $variables['vocabulary_machine_name'] == 'cities' ? t('Location during writing of book') : '';
 }

--- a/haskala/themes/custom/haskala_theme/templates/taxonomy-term--detailed.tpl.php
+++ b/haskala/themes/custom/haskala_theme/templates/taxonomy-term--detailed.tpl.php
@@ -1,0 +1,10 @@
+<div class="field field-name-field-current-name field-type-text field-label-above">
+  <div class="field-label"><?php print $title_label; ?>:</div>
+  <div class="field-items">
+    <div class="field-item even">
+      <a href="<?php print $term_url; ?>"><?php print $term_name; ?></a>
+    </div>
+  </div>
+</div>
+
+<?php print render($content); ?>


### PR DESCRIPTION
#105 
It's now possible to set a "Current name" on a city, and it will show on the producer tab:
![screen shot 2015-02-09 at 13 07 21](https://cloud.githubusercontent.com/assets/2283680/6108368/1450b8ee-b07b-11e4-92b0-a9634f416408.png)

![screen shot 2015-02-09 at 16 41 32](https://cloud.githubusercontent.com/assets/2283680/6108367/144c9296-b07b-11e4-850c-ae90e217c19a.png)

